### PR TITLE
librsvg 2.56.3: Rebuild against harfbuzz-10.2.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,7 +2,3 @@
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
-
-channels:
-  - https://staging.continuum.io/prefect/fs/harfbuzz-feedstock/pr20/62acfe5
-  - https://staging.continuum.io/prefect/fs/pango-feedstock/pr2/06cea1b

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,3 +5,4 @@ build_parameters:
 
 channels:
   - https://staging.continuum.io/prefect/fs/harfbuzz-feedstock/pr20/62acfe5
+  - https://staging.continuum.io/prefect/fs/pango-feedstock/pr2/06cea1b

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,6 @@
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
+
+channels:
+  - https://staging.continuum.io/prefect/fs/harfbuzz-feedstock/pr20/62acfe5

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,5 @@
 c_compiler:        # [win]
   - vs2022         # [win]
+
+harfbuzz:
+  - 10

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 build:
   skip: true # [win and vc<14]
-  number: 0
+  number: 1
   run_exports:
     # Looks good but no new info after 2.43 so keeping it x.x for safety.
     # https://abi-laboratory.pro/?view=timeline&l=librsvg


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-6988](https://anaconda.atlassian.net/browse/PKG-6988) 
- [Upstream repository]()

### Explanation of changes:

- Bump build number to 1
- Add a local cbc.yaml with harfbuzz 10

### Notes:

-

[PKG-6988]: https://anaconda.atlassian.net/browse/PKG-6988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ